### PR TITLE
Feat/#2/bottom modal

### DIFF
--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -18,7 +18,11 @@ const Home = () => {
       <BottomModal isOpen={isBottomOpen} onClose={() => setIsBottomOpen(false)} />
 
       {/* 중앙 모달 */}
-      <CenterModal isOpen={isCenterOpen} onClose={() => setIsCenterOpen(false)} />
+      <CenterModal isOpen={isCenterOpen} onClose={() => setIsCenterOpen(false)}>
+        <h1>모달 제목</h1>
+        <p>모달 내용입니다.</p>
+        <div>dfdfdfdf</div>
+      </CenterModal>
     </RegisterWrapper>
   );
 };

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,16 +1,24 @@
 "use client";
 
 import BottomModal from "@/components/BottomModal";
+import CenterModal from "@/components/CenterModal";
 import { useState } from "react";
 import styled from "styled-components";
 
 const Home = () => {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isBottomOpen, setIsBottomOpen] = useState(false);
+  const [isCenterOpen, setIsCenterOpen] = useState(false);
 
   return (
     <RegisterWrapper>
-      <button onClick={() => setIsOpen(true)}>모달 열기</button>
-      <BottomModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+      <Button onClick={() => setIsBottomOpen(true)}>하단 모달 열기</Button>
+      <Button onClick={() => setIsCenterOpen(true)}>중앙 모달 열기</Button>
+
+      {/* 하단 모달 */}
+      <BottomModal isOpen={isBottomOpen} onClose={() => setIsBottomOpen(false)} />
+
+      {/* 중앙 모달 */}
+      <CenterModal isOpen={isCenterOpen} onClose={() => setIsCenterOpen(false)} />
     </RegisterWrapper>
   );
 };
@@ -18,8 +26,27 @@ const Home = () => {
 export default Home;
 
 const RegisterWrapper = styled.div`
-   width: 100%;
-   display: flex;
-   justify-content: center;
-   align-items: center;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  height: 100vh;
+`;
+
+const Button = styled.button`
+  background: black;
+  color: white;
+  padding: 12px 20px;
+  font-size: 1rem;
+  font-weight: bold;
+  border: none;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: background 0.2s;
+
+  &:hover {
+    background: #222;
+  }
 `;

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import BottomModal from "@/components/BottomModal";
+import { useState } from "react";
+import styled from "styled-components";
+
+const Home = () => {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <RegisterWrapper>
+      <button onClick={() => setIsOpen(true)}>모달 열기</button>
+      <BottomModal isOpen={isOpen} onClose={() => setIsOpen(false)} />
+    </RegisterWrapper>
+  );
+};
+
+export default Home;
+
+const RegisterWrapper = styled.div`
+   width: 100%;
+   display: flex;
+   justify-content: center;
+   align-items: center;
+`;

--- a/src/app/register/page.tsx
+++ b/src/app/register/page.tsx
@@ -15,12 +15,14 @@ const Home = () => {
       <Button onClick={() => setIsCenterOpen(true)}>중앙 모달 열기</Button>
 
       {/* 하단 모달 */}
-      <BottomModal isOpen={isBottomOpen} onClose={() => setIsBottomOpen(false)} />
+      <BottomModal isOpen={isBottomOpen} onClose={() => setIsBottomOpen(false)} title="모달 제목">
+        <p>bottomModal 내용 예시입니다.</p>
+        <div>dfdfdfdf</div>
+      </BottomModal>
 
       {/* 중앙 모달 */}
       <CenterModal isOpen={isCenterOpen} onClose={() => setIsCenterOpen(false)}>
-        <h1>모달 제목</h1>
-        <p>모달 내용입니다.</p>
+        <p>centerModal 내용 예시입니다.</p>
         <div>dfdfdfdf</div>
       </CenterModal>
     </RegisterWrapper>

--- a/src/components/BottomModal.tsx
+++ b/src/components/BottomModal.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import { useEffect } from "react";
+import styled from "styled-components";
+
+interface ModalProps {
+   isOpen: boolean;
+   onClose: () => void;
+}
+
+const BottomModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
+   useEffect(() => {
+      if (isOpen) {
+         document.body.style.overflow = "hidden";
+      } else {
+         document.body.style.overflow = "auto";
+      }
+
+      return () => {
+         document.body.style.overflow = "auto";
+      };
+   }, [isOpen]);
+
+   if (!isOpen) return null;
+
+   return (
+      <ModalOverlay onClick={onClose}>
+         <ModalContainer onClick={(e) => e.stopPropagation()}>
+         <CloseButton onClick={onClose}>×</CloseButton>
+            <ModalWrapper>
+               여기에 내용을 넣어주세용~~(칸 크기 보라고 border 해놓음)
+            </ModalWrapper>
+         </ModalContainer>
+      </ModalOverlay>
+   );
+};
+
+// 모달 배경 (클릭 시 닫힘)
+const ModalOverlay = styled.div`
+      
+   position: fixed;
+   inset: 0;
+   background: rgba(0, 0, 0, 0.5);
+   display: flex;
+   justify-content: center;
+   align-items: flex-end;
+   z-index: 1000;
+`;
+
+// 모달 컨테이너 (슬라이드 애니메이션 포함)
+const ModalContainer = styled.div`
+   width: 100%;
+   max-width: 490px;
+   height: 75%;
+   background: white;
+   border-radius: 12px 12px 0 0;
+   position: relative;
+   transform: translateY(100%);
+   animation: slideUp 0.3s forwards;
+
+   @keyframes slideUp {
+      from {
+         transform: translateY(100%);
+      }
+      to {
+         transform: translateY(0);
+      }
+   }
+
+   display: flex;
+   flex-direction: column;
+   justify-content: flex-start;
+   align-items: center;
+`;
+
+const ModalWrapper = styled.div`
+   width: 80%;
+   padding: 20px;
+
+   border: 1px solid black;
+`;
+
+// 닫기 버튼
+const CloseButton = styled.button`
+   width: 30px;
+   align-self: flex-end;
+
+   font-size: 20px;
+   font-weight: bold;
+   color: black;
+   background: none;
+   border: none;
+   cursor: pointer;
+   margin: 10px;
+   padding: 0;
+
+`;
+
+export default BottomModal;

--- a/src/components/BottomModal.tsx
+++ b/src/components/BottomModal.tsx
@@ -1,14 +1,16 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, ReactNode } from "react";
 import styled from "styled-components";
 
 interface ModalProps {
    isOpen: boolean;
    onClose: () => void;
+   title: string; 
+   children?: ReactNode; 
 }
 
-const BottomModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
+const BottomModal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
    useEffect(() => {
       if (isOpen) {
          document.body.style.overflow = "hidden";
@@ -26,10 +28,11 @@ const BottomModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
    return (
       <ModalOverlay onClick={onClose}>
          <ModalContainer onClick={(e) => e.stopPropagation()}>
-         <CloseButton onClick={onClose}>×</CloseButton>
-            <ModalWrapper>
-               여기에 내용을 넣어주세용~~(칸 크기 보라고 border 해놓음)
-            </ModalWrapper>
+            <Title>
+               <span style={{fontSize:'20px', fontWeight:'bold', marginLeft:'10px'}}>{title}</span>
+               <CloseButton onClick={onClose}>×</CloseButton>
+            </Title>
+            <ModalWrapper>{children}</ModalWrapper>
          </ModalContainer>
       </ModalOverlay>
    );
@@ -37,7 +40,6 @@ const BottomModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
 
 // 모달 배경 (클릭 시 닫힘)
 const ModalOverlay = styled.div`
-      
    position: fixed;
    inset: 0;
    background: rgba(0, 0, 0, 0.5);
@@ -49,6 +51,7 @@ const ModalOverlay = styled.div`
 
 // 모달 컨테이너 (슬라이드 애니메이션 포함)
 const ModalContainer = styled.div`
+   font-family: "pretendard-regular", sans-serif;
    width: 100%;
    max-width: 490px;
    height: 75%;
@@ -76,24 +79,30 @@ const ModalContainer = styled.div`
 const ModalWrapper = styled.div`
    width: 80%;
    padding: 20px;
+`;
 
-   border: 1px solid black;
+// 모달 제목
+const Title = styled.div`
+   width: 90%;
+   height: 50px;
+   display: flex;
+   justify-content: space-between;
+   align-items: center;
+   margin-top: 15px;
+
+   border-bottom: 1px solid #eee;
 `;
 
 // 닫기 버튼
 const CloseButton = styled.button`
-   width: 30px;
    align-self: flex-end;
-
-   font-size: 20px;
-   font-weight: bold;
+   font-size: 30px;
    color: black;
    background: none;
    border: none;
    cursor: pointer;
    margin: 10px;
    padding: 0;
-
 `;
 
 export default BottomModal;

--- a/src/components/CenterModal.tsx
+++ b/src/components/CenterModal.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect } from "react";
+import styled from "styled-components";
+
+interface ModalProps {
+   isOpen: boolean;
+   onClose: () => void;
+}
+
+const CenterModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
+   useEffect(() => {
+      if (isOpen) {
+         document.body.style.overflow = "hidden";
+      } else {
+         document.body.style.overflow = "auto";
+      }
+
+      return () => {
+         document.body.style.overflow = "auto";
+      };
+   }, [isOpen]);
+
+   if (!isOpen) return null;
+
+   return (
+      <ModalOverlay onClick={onClose}>
+         <ModalContainer onClick={(e) => e.stopPropagation()}>
+            <ModalTitle>대면 컨설팅을 선택했어요</ModalTitle>
+            <ModalContent>
+               <p>대면 컨설팅을 선택하셨습니다.</p>
+               <p>대면 컨설팅은 예약 시간에 방문하셔야 합니다.</p>
+               <p>예약 시간에 방문하지 않을 경우, 예약이 취소될 수 있습니다.</p>
+            </ModalContent>
+            <ConfirmButton onClick={onClose}>확인했어요</ConfirmButton>
+         </ModalContainer>
+      </ModalOverlay>
+   );
+};
+
+// 배경 (모달 외부 클릭 시 닫힘)
+const ModalOverlay = styled.div`
+   position: fixed;
+   inset: 0;
+   background: rgba(0, 0, 0, 0.5);
+   display: flex;
+   justify-content: center;
+   align-items: center;
+   z-index: 1000;
+   animation: fadeIn 0.3s;
+
+   @keyframes fadeIn {
+      from { opacity: 0; }
+      to { opacity: 1; }
+   }
+`;
+
+// 모달 박스
+const ModalContainer = styled.div`
+   width: 85%;
+   max-width: 320px;
+   background: white;
+   text-align: center;
+   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.2);
+   animation: slideDown 0.3s;
+
+   @keyframes slideDown {
+      from { transform: translateY(-20px); opacity: 0; }
+      to { transform: translateY(0); opacity: 1; }
+   }
+`;
+
+// 모달 제목
+const ModalTitle = styled.h2`
+   padding: 16px;
+   font-size: 1.2rem;
+   border-bottom: 1px solid #eee;
+`;
+
+// 모달 내용
+const ModalContent = styled.div`
+   padding: 16px;
+   font-size: 1rem;
+`;
+
+
+// 확인 버튼
+const ConfirmButton = styled.button`
+   width: 100%;
+   background: black;
+   color: white;
+   padding: 12px;
+   font-size: 1.2rem;
+   border: none;
+   margin-top: 16px;
+   cursor: pointer;
+
+   &:hover {
+      background: #222;
+   }
+`;
+
+export default CenterModal;

--- a/src/components/CenterModal.tsx
+++ b/src/components/CenterModal.tsx
@@ -6,9 +6,12 @@ import styled from "styled-components";
 interface ModalProps {
    isOpen: boolean;
    onClose: () => void;
+   title?: string; // 제목을 동적으로 설정
+   content?: string[]; // 여러 줄의 내용을 받을 수 있도록 배열 형태
+   children?: React.ReactNode; // JSX 요소를 직접 받을 수도 있음
 }
 
-const CenterModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
+const CenterModal: React.FC<ModalProps> = ({ isOpen, onClose, title, content, children }) => {
    useEffect(() => {
       if (isOpen) {
          document.body.style.overflow = "hidden";
@@ -26,11 +29,11 @@ const CenterModal: React.FC<ModalProps> = ({ isOpen, onClose }) => {
    return (
       <ModalOverlay onClick={onClose}>
          <ModalContainer onClick={(e) => e.stopPropagation()}>
-            <ModalTitle>대면 컨설팅을 선택했어요</ModalTitle>
+            {/* 제목이 있으면 렌더링 */}
+            {title && <ModalTitle>{title}</ModalTitle>}
             <ModalContent>
-               <p>대면 컨설팅을 선택하셨습니다.</p>
-               <p>대면 컨설팅은 예약 시간에 방문하셔야 합니다.</p>
-               <p>예약 시간에 방문하지 않을 경우, 예약이 취소될 수 있습니다.</p>
+               {/* content 배열이 있으면 각 줄을 p 태그로 출력 */}
+               {content ? content.map((line, index) => <p key={index}>{line}</p>) : children}
             </ModalContent>
             <ConfirmButton onClick={onClose}>확인했어요</ConfirmButton>
          </ModalContainer>
@@ -57,6 +60,7 @@ const ModalOverlay = styled.div`
 
 // 모달 박스
 const ModalContainer = styled.div`
+   font-family: "pretendard-regular", sans-serif;
    width: 85%;
    max-width: 320px;
    background: white;


### PR DESCRIPTION
## 이슈 번호
#2 #3 

## 🛠️ 한 줄 요약

한줄요약

centerModal과 bottomModal 구현

## 상세

### 🔥 바꾼거

1. centerModal로 children props를 넘겨서 컴포넌트를 그대로 넘겨줄 수 있음
2. bottomModal도 마찬가지로 컴포넌트를 넘겨줄 수 있고, 더해서 title도 문자열로 넘겨주면 상단의 엑스표시 좌측에 제목으로 표시됨


